### PR TITLE
allow custom shortcut directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
+## [0.2.0] - 2023-01-02
+### Added
+- Added option to use custom shortcut directories.
+
 ## [0.1.0] - 2022-12-25
 ### Added
 - Initial release.
 
 [0.1.0]: https://github.com/LizardByte/GSMS/releases/tag/v0.1.0
+[0.2.0]: https://github.com/LizardByte/GSMS/releases/tag/v0.2.0

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,20 @@ understanding of using the command line. The script can be run with a variety of
 such as specifying the `apps.json` file to update, the directory where to copy box art images, and whether to preview
 the changes without actually updating the `apps.json` file.
 
+As an alternative option to migrating custom Gamestream apps, you may also migrate any directory containing
+``.lnk`` (shortcut) files. Below is the preferred directory structure of a custom directory. Cover images
+(``box-art.png``) is optional.
+
+.. code-block::
+
+   .
+   ├── A Game.lnk
+   ├── Another Game.lnk
+   └── StreamingAssets
+       ├── A Game
+       │   └── box-art.png
+       └── Another Game
+           └── box-art.png
 
 Usage
 -----
@@ -52,6 +66,10 @@ OPTIONS
 ``--image_path, -i``
     Specify the full directory where to copy box art to. If not specified, box art will be copied to
     ``%USERPROFILE%/Pictures/Sunshine``
+
+``--shortcut_dir, -s``
+    Specify a custom shortcut directory. If not specified, ``%localappdata%/NVIDIA Corporation/Shield Apps``
+    will be used.
 
 ``--dry_run, -d``
     If set, the ``apps.json`` file will not be overwritten. Use this flag to preview the changes that would be made


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- This PR adds the ability to specify a custom shortcut directory, inspired by this feature request: https://feedback.lizardbyte.dev/suggestions/351812/gsms-gerneral-shortcut-support-export-from-steam


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
