### PR TITLE
Add GFE autodetected applications

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,8 +72,11 @@ OPTIONS
     will be used.
 
 ``--dry_run, -d``
-    If set, the ``apps.json`` file will not be overwritten. Use this flag to preview the changes that would be made
-    without committing them.
+    If set, the ``apps.json`` file will not be overwritten the changes that would be made and box-art images won\'t be copied.
+    Use this flag to preview the changes that would be made without committing them.
+
+``--nv_add_autodetect, -n``
+    If set, GSMS will import the streamable autodetected apps from NVIDIA GFE GameStream.
 
 ``--no_sleep``
     If set, the script will not pause for 10 seconds at the end of the import.

--- a/README.rst
+++ b/README.rst
@@ -3,23 +3,24 @@ Overview
 
 About
 -----
-GSMS is a migration tool that allows users to import their custom apps and games from Nvidia Gamestream to
-`Sunshine <https://github.com/LizardByte/Sunshine>`_. Note that Nvidia Gamestream support will end in February 2023,
-so users who rely on Gamestream may want to consider migrating their library to Sunshine. This program updates the
+GSMS is a migration tool that allows users to import their custom apps and games from Nvidia GameStream to
+`Sunshine <https://github.com/LizardByte/Sunshine>`_. Note that Nvidia GameStream support has ended in February 2023,
+so users who relied on GameStream may want to consider migrating their library to Sunshine. This program updates the
 `apps.json` file for Sunshine and copies the corresponding box art images to a specified directory. It reads shortcut
-files (.lnk) from the default Gamestream installation location and adds them to Sunshine as new apps. If an app with
+files (.lnk) from the default GameStream installation location. Additionally it can add games that were automatically
+detected by Nvidia GameStream. The found games and applications are added to Sunshine as new apps. If an app with
 the same name already exists in Sunshine, it will be skipped.
 
-This program is intended for users who want to migrate their Gamestream library to Sunshine and have their custom apps
+This program is intended for users who want to migrate their GameStream library to Sunshine and have their custom apps
 and games available in Sunshine. It can save users the time and effort of manually adding each app to Sunshine and
-finding and copying the corresponding box art images. The Gamestraem library and box-art images will not be modified.
+finding and copying the corresponding box art images. The GameStream library and box-art images will not be modified.
 
-To use this script, users will need to have both Gamestream and Sunshine installed on their system and have a basic
+To use this script, users will need to have both GameStream and Sunshine installed on their system and have a basic
 understanding of using the command line. The script can be run with a variety of options to customize its behavior,
 such as specifying the `apps.json` file to update, the directory where to copy box art images, and whether to preview
 the changes without actually updating the `apps.json` file.
 
-As an alternative option to migrating custom Gamestream apps, you may also migrate any directory containing
+As an alternative option to migrating custom GameStream apps, you may also migrate any directory containing
 ``.lnk`` (shortcut) files. Below is the preferred directory structure of a custom directory. Cover images
 (``box-art.png``) is optional.
 
@@ -72,25 +73,25 @@ OPTIONS
     will be used.
 
 ``--dry_run, -d``
-    If set, the ``apps.json`` file will not be overwritten the changes that would be made and box-art images won\'t be copied.
-    Use this flag to preview the changes that would be made without committing them.
-
-``--nv_add_autodetect, -n``
-    If set, GSMS will import the streamable autodetected apps from NVIDIA GFE GameStream.
+    If set, the `apps.json` file will not be overwritten and box-art images won't be copied. Use this flag to preview
+    the changes that would be made without committing them.
 
 ``--no_sleep``
     If set, the script will not pause for 10 seconds at the end of the import.
 
+``--nv_add_autodetect, -n``
+    If set, the script will add all streamable apps from Nvidia GameStream's automatically detected applications.
+
 Examples
 ^^^^^^^^
 
-To migrate all Gamestream apps to Sunshine and copy box art images to the default directory:
+To migrate all GameStream apps to Sunshine and copy box art images to the default directory:
 
 .. code-block:: batch
 
    gsms.exe
 
-To migrate all Gamestream apps to Sunshine and copy box art images to a custom directory:
+To migrate all GameStream apps to Sunshine and copy box art images to a custom directory:
 
 .. code-block:: batch
 

--- a/gsms.py
+++ b/gsms.py
@@ -357,9 +357,11 @@ def copy_image(src_image, dst_image):
     Copies an image from src_image to dst_image if the dst is empty or different
 
     Parameters
-    -------
-    src_image: string
-    dst_image: string
+    ----------
+    src_image: str
+        Source path of the image
+    dst_image: str
+        Destination path of the image
 
     Returns
     -------
@@ -382,9 +384,11 @@ def has_app(sunshine_apps, name):
     Checks if a given app name is in the sunshine_apps object
 
     Parameters
-    -------
+    ----------
     sunshine_apps: Object
+        Parsed JSON object of the sunshine `apps.json`
     name: string
+        Name to check for
 
     Returns
     -------
@@ -411,13 +415,19 @@ def add_game(sunshine_apps, name, logfile, cmd, working_dir, image_path):
     Function to add an app to the sunshine_apps object passed in
 
     Parameters
-    -------
+    ----------
     sunshine_apps: Object
-    name: string
-    logfile: string
-    cmd: string
-    working_dir: string
-    image_path: string
+        Parsed JSON object of the sunshine `apps.json`
+    name: str
+        Name of the app
+    logfile: str
+        Logfile name for the app
+    cmd: str
+        Commandline to start the app
+    working_dir: str
+        Working directory for the app
+    image_path: str
+        Path to an image file to display as box-art
 
     Returns
     -------

--- a/gsms.py
+++ b/gsms.py
@@ -272,7 +272,7 @@ def add_game(sunshine_apps: dict, name: str, logfile: str, cmd: str, working_dir
             cmd = f"steam {cmd}"
     # if it's not a URI we check if the command includes the working_directory
     elif not cmd.startswith(working_dir):
-        cmd = os.path.join(working_dir, cmd)  
+        cmd = os.path.join(working_dir, cmd)
 
     data = {
         'name': name,
@@ -280,13 +280,13 @@ def add_game(sunshine_apps: dict, name: str, logfile: str, cmd: str, working_dir
         'working-dir': working_dir,
         'image-path': image_path
     }
-    
+
     # we add the command to the appropriate field
     if detached:
         data['detached'] = [cmd]
     else:
         data['cmd'] = cmd
-    
+
     sunshine_apps['apps'].append(data)
 
 

--- a/gsms.py
+++ b/gsms.py
@@ -35,6 +35,9 @@ OPTIONS
 --no_sleep
     If set, the script will not pause for 10 seconds at the end of the import.
 
+--nv_add_autodetect, -n
+    If set, the swcript will add all streamable apps from NVidia GFE's autodetected applications
+
 Examples
 --------
 

--- a/gsms.py
+++ b/gsms.py
@@ -352,7 +352,7 @@ def main() -> None:
                                 'custom location.')
 
 
-def copy_image(src_image, dst_image):
+def copy_image(src_image, dst_image) -> None:
     """
     Copies an image from src_image to dst_image if the dst is empty or different
 
@@ -379,7 +379,7 @@ def copy_image(src_image, dst_image):
         print(f'No box-art image found at: {src_image}')
 
 
-def has_app(sunshine_apps, name):
+def has_app(sunshine_apps, name) -> bool:
     """
     Checks if a given app name is in the sunshine_apps object
 
@@ -392,7 +392,8 @@ def has_app(sunshine_apps, name):
 
     Returns
     -------
-    True if the app is in the sunshine_apps object. Otherwise False
+    bool:
+        True if the app is in the sunshine_apps object. Otherwise False
 
     Examples
     --------
@@ -410,7 +411,7 @@ def has_app(sunshine_apps, name):
     return app_exists
 
 
-def add_game(sunshine_apps, name, logfile, cmd, working_dir, image_path):
+def add_game(sunshine_apps, name, logfile, cmd, working_dir, image_path) -> None:
     """
     Function to add an app to the sunshine_apps object passed in
 

--- a/gsms.py
+++ b/gsms.py
@@ -2,7 +2,7 @@
 """
 gsms.py
 
-A migration tool for Nvidia Gamestream to Sunshine.
+A migration tool for Nvidia GameStream to Sunshine.
 
 This script updates the `apps.json` file for Sunshine and copies box art images to a specified directory. It reads
 shortcut files (.lnk) from a specified directory and adds them to Sunshine as new apps. If an
@@ -36,16 +36,16 @@ OPTIONS
     If set, the script will not pause for 10 seconds at the end of the import.
 
 --nv_add_autodetect, -n
-    If set, GSMS will import the streamable autodetected apps from NVIDIA GFE GameStream.
+    If set, the script will add all streamable apps from Nvidia GameStream's automatically detected applications.
 
 Examples
 --------
 
-To migrate all Gamestream apps to Sunshine and copy box art images to the default directory:
+To migrate all GameStream apps to Sunshine and copy box art images to the default directory:
 
 $ python gsms.py
 
-To migrate all Gamestream apps to Sunshine and copy box art images to a custom directory:
+To migrate all GameStream apps to Sunshine and copy box art images to a custom directory:
 
 $ python gsms.py --image_path /path/to/custom/dir
 
@@ -162,7 +162,7 @@ def get_win_path(folder_id: str) -> str:
 
 def copy_image(src_image: str, dst_image: str) -> None:
     """
-    Copies an image from src_image to dst_image if the dst is empty or different.
+    Copy an image from `src_image` to `dst_image` if the destination image does not exist.
 
     Parameters
     ----------
@@ -173,7 +173,7 @@ def copy_image(src_image: str, dst_image: str) -> None:
 
     Examples
     --------
-    >>> copy_image("C:\\Image1.png", "D:\\Image1.png")
+    >>> copy_image(src_image="C:\\Image1.png", dst_image="D:\\Image1.png")
     """
     # if src_image exists and dst_image does not exist
     if os.path.isfile(src_image) and not os.path.isfile(dst_image):
@@ -190,18 +190,18 @@ def has_app(sunshine_apps: dict, name: str) -> bool:
     Parameters
     ----------
     sunshine_apps : dict
-        The parsed JSON dict of the ``apps.json``.
+        Dictionary object of the sunshine `apps.json`.
     name : str
         Name to check for.
 
     Returns
     -------
     bool
-        True if the app is in the sunshine_apps object. Otherwise False.
+        True if the app is in the sunshine_apps object, otherwise False.
 
     Examples
     --------
-    >>> has_app({}, "Game Name")
+    >>> has_app(sunshine_apps={}, name="Game Name")
     False
     """
     app_exists = False
@@ -217,12 +217,12 @@ def has_app(sunshine_apps: dict, name: str) -> bool:
 
 def add_game(sunshine_apps: dict, name: str, logfile: str, cmd: str, working_dir: str, image_path: str) -> None:
     """
-    Function to add an app to the sunshine_apps object passed in.
+    Add an app to the sunshine_apps object.
 
     Parameters
     ----------
     sunshine_apps : dict
-        The parsed JSON dict of the ``apps.json``.
+        Dictionary object of the sunshine `apps.json`.
     name : str
         Name of the app.
     logfile : str
@@ -236,11 +236,11 @@ def add_game(sunshine_apps: dict, name: str, logfile: str, cmd: str, working_dir
 
     Examples
     --------
-    >>> add_game({}, "Game Name", "game.log", "game.exe", "C:\\gamedir", "C:\\gamedir\\image.png")
+    >>> add_game(sunshine_apps={}, name="Game Name", logfile="game.log", cmd="game.exe",
+    >>>          working_dir="C:\\game_dir", image_path="C:\\game_dir\\image.png")
     """
-
-    working_dir = known_path_to_absolute(working_dir)
-    cmd = known_path_to_absolute(cmd)
+    working_dir = known_path_to_absolute(path=working_dir)
+    cmd = known_path_to_absolute(path=cmd)
 
     # remove final path separator but only if it exists
     while working_dir.endswith(os.sep):
@@ -265,7 +265,7 @@ def add_game(sunshine_apps: dict, name: str, logfile: str, cmd: str, working_dir
     if '://' in cmd:
         detached = True
 
-        # if the URI uses the steam protocol we prepend the steam executeable
+        # if the URI uses the steam protocol we prepend the steam executable
         if 'steam://' in cmd:
             cmd = f"steam {cmd}"
     # if it's not a URI we check if the command includes the working_directory
@@ -290,21 +290,21 @@ def add_game(sunshine_apps: dict, name: str, logfile: str, cmd: str, working_dir
 
 def known_path_to_absolute(path: str) -> str:
     """
-    Function to convert paths containing windows known path UUIDs to absolute paths.
+    Convert paths containing Windows known path UUID to absolute path.
 
     Parameters
     ----------
     path : str
-        Path that may contain windows known paths.
+        Path that may contain Windows UUID.
 
     Returns
     -------
     str
-        Path with all windows known UUIDs to absolute paths.
+        The absolute path.
 
     Examples
     --------
-    >>> known_path_to_absolute('::{62AB5D82-FDC1-4DC3-A9DD-070D1D495D97}')
+    >>> known_path_to_absolute(path='::{62AB5D82-FDC1-4DC3-A9DD-070D1D495D97}')
     C:\\ProgramData
     """
     # prepare regex to get folder UUIDs which can only be at the start exactly 1 time with 2 preceding colons
@@ -317,7 +317,7 @@ def known_path_to_absolute(path: str) -> str:
     if len(path_result) == 1:
         path = path.replace(
             f"::{path_result[0]}",
-            get_win_path(path_result[0])
+            get_win_path(folder_id=path_result[0])
         )
 
     return path
@@ -333,10 +333,6 @@ def stopwatch(message: str, sec: int) -> None:
         Prefix message to display before the countdown timer.
     sec : int
         Time, in seconds, to countdown from.
-
-    Returns
-    -------
-    None
 
     Examples
     --------
@@ -359,10 +355,6 @@ def main() -> None:
     Main application entrypoint. Migrates Nvidia Gamestream apps to Sunshine by updating the `apps.json` file and
     copying box art images to a specified directory.
 
-    Returns
-    -------
-    None
-
     Raises
     ------
     FileNotFoundError
@@ -374,7 +366,7 @@ def main() -> None:
     ...
     """
     # Set up and gather command line arguments
-    parser = argparse.ArgumentParser(description='GSMS is a migration tool for Nvidia Gamestream to Sunshine.')
+    parser = argparse.ArgumentParser(description='GSMS is a migration tool for Nvidia GameStream to Sunshine.')
 
     parser.add_argument('--apps', '-a',
                         help='Specify the sunshine `apps.json` file to update, otherwise we will attempt to use the '
@@ -397,7 +389,7 @@ def main() -> None:
     parser.add_argument('--no_sleep', action='store_true',
                         help='If set, the script will not pause for 10 seconds at the end of the import.')
     parser.add_argument('--nv_add_autodetect', '-n', action='store_true',
-                        help='If set, GSMS will import the streamable autodetected apps from NVIDIA GFE GameStream.')
+                        help='If set, GSMS will import the automatically detected apps from Nvidia GameStream.')
 
     args = parser.parse_args()
 
@@ -406,7 +398,7 @@ def main() -> None:
 
     # create some helper path variables for later usage
     nvidia_base_dir = os.path.join(os.environ['localappdata'], "NVIDIA", "NvBackend")
-    # Path for the main application xml NVidia GFE uses
+    # Path for the main application xml Nvidia GFE uses
     nvidia_autodetect_dir = os.path.join(nvidia_base_dir, "journalBS.main.xml")
     # Base folder for the box-art
     nvidia_images_base_dir = os.path.join(nvidia_base_dir, "StreamingAssetsData")
@@ -433,7 +425,7 @@ def main() -> None:
 
                 shortcut = pylnk3.parse(lnk=os.path.join(args.shortcut_dir, gs_app))
                 shortcut.work_dir = "" if shortcut.work_dir is None else shortcut.work_dir
-                print(f'Found gamestream app: {name}')
+                print(f'Found GameStream app: {name}')
                 print(f'working-dir: {shortcut.work_dir}')
                 print(f'path: {shortcut.path}')
 
@@ -480,15 +472,15 @@ def main() -> None:
                 if has_app(sunshine_apps=sunshine_apps, name=name):
                     continue
 
-                # Increae count here to exclude some stuff
+                # Increase count here to exclude some stuff
                 count += 1
 
                 cmd = application.find("StreamingCommandLine").text
                 working_dir = application.find("InstallDirectory").text
-                # NVidia's short_name is a pre-shortened and filesystem safe name for the game
+                # Nvidia's short_name is a pre-shortened and filesystem safe name for the game
                 short_name = application.find("ShortName").text
 
-                print(f'Found gamestream app: {name}')
+                print(f'Found GameStream app: {name}')
                 print(f'working-dir: {working_dir}')
                 print(f'path: {cmd}')
 
@@ -516,7 +508,7 @@ def main() -> None:
             with open(file=args.apps, mode="w") as f:
                 json.dump(obj=sunshine_apps, indent=4, fp=f)
         print(json.dumps(obj=sunshine_apps, indent=4))
-        print('Completed importing Nvidia gamestream games.')
+        print('Completed importing Nvidia GameStream games.')
         print(f'Added {count} apps to Sunshine.')
         if not args.no_sleep:
             stopwatch(message='Exiting in: ', sec=10)

--- a/gsms.py
+++ b/gsms.py
@@ -260,11 +260,13 @@ def add_game(sunshine_apps: any, name: str, logfile: str, cmd: str, working_dir:
     while cmd.startswith(os.sep):
         cmd = cmd[1:]
 
+    # we don't need ot keep quotes around the path or working directory
+    working_dir = working_dir.replace('"', "")
     cmd = cmd.replace('"', '')
 
     # steam URI commands need some special treatment
     if cmd.startswith("start steam://"):
-        # make the cmd easily launchable via steam if its a steam URI
+        # make the cmd easily launchable via steam if it's a steam URI
         cmd = cmd.replace('start steam://', 'steam steam://')
 
         sunshine_apps['apps'].append(
@@ -278,7 +280,7 @@ def add_game(sunshine_apps: any, name: str, logfile: str, cmd: str, working_dir:
         )
 
     else:
-        # assemble clean command path if it wasnt a full path yet
+        # assemble clean command path if it wasn't a full path yet
         if not cmd.startswith(working_dir):
             cmd = os.path.join(working_dir, cmd)
 

--- a/gsms.py
+++ b/gsms.py
@@ -157,8 +157,6 @@ def get_win_path(folder_id: str) -> str:
     # Free memory used by pointer
     _CoTaskMemFree(path_pointer)
 
-    print(path)
-
     return path
 
 


### PR DESCRIPTION
## Description
This PR adds a new flag `-n` (short for `--nv_add_autodetect`) which adds all autodetected applications from GFE marked as `streamable`. It also breaks out a few things into separate functions as they get reused between the GameStream shotcuts folder loop and XML loop.

The only thing I can think of to improve on this PR at the moment would be the JSON related type hints on the new functions.


### Issues Fixed or Closed


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
