### PR TITLE
ci: fix moonlight release notifier

### DIFF
--- a/.github/workflows/release-notifier-moonlight.yml
+++ b/.github/workflows/release-notifier-moonlight.yml
@@ -3,10 +3,15 @@ name: Release Notifications (Moonlight)
 
 on:
   release:
-    types: [published]
+    types:
+      - released  # this triggers when a release is published, but does not include prereleases or drafts
 
 jobs:
   discord:
+    if: >-
+      startsWith(github.repository, 'LizardByte/') &&
+      !github.event.release.prerelease &&
+      !github.event.release.draft
     runs-on: ubuntu-latest
     steps:
       - name: discord


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
See the following:

- https://github.com/LizardByte/.github/pull/334
- https://github.com/LizardByte/Sunshine/pull/2553


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
